### PR TITLE
providers: don't send empty body/usage lines to IRC

### DIFF
--- a/sopel_help/providers.py
+++ b/sopel_help/providers.py
@@ -143,9 +143,11 @@ class AbstractGeneratedProvider(AbstractProvider):
 
         reply(head, recipient)
         for line in body:
-            bot.say(line, recipient)
+            if line:
+                bot.say(line, recipient)
         for line in usages:
-            bot.say(line, recipient)
+            if line:
+                bot.say(line, recipient)
 
     def get_reply_method(self, bot, trigger):
         """Define the reply method and its recipient.


### PR DESCRIPTION
There's no effect visible to the user, but we can eliminate an unnecessary error (412) from the IRC server.

**Before:**

```
2023-11-09 21:49:41,145 >>      "PRIVMSG dgw :Manage Sopel's blocking features.\r\n"
2023-11-09 21:49:41,146 >>      'PRIVMSG dgw :\r\n'
2023-11-09 21:49:41,147 >>      'PRIVMSG dgw :Full argspec: `list [nick|host]` or `[add|del] [nick|host] pattern`\r\n'
2023-11-09 21:49:41,148 >>      'PRIVMSG dgw :e.g. .blocks add nick sp(a|4)mb(o|0)t\\d*, .blocks add host some\\.malicious\\.network or .blocks del nick falsep0sitive\r\n'
2023-11-09 21:49:41,193 <<      ':irc.rizon.io 412 SopelTest :No text to send\r\n'
```

**After:**

```
2023-11-09 22:07:00,389 >>      "PRIVMSG dgw :Manage Sopel's blocking features.\r\n"
2023-11-09 22:07:00,390 >>      'PRIVMSG dgw :Full argspec: `list [nick|host]` or `[add|del] [nick|host] pattern`\r\n'
2023-11-09 22:07:00,391 >>      'PRIVMSG dgw :e.g. .blocks add nick sp(a|4)mb(o|0)t\\d*, .blocks add host some\\.malicious\\.network or .blocks del nick falsep0sitive\r\n'
```