### PR TITLE
managers, meta: migrate off of `pkg_resources` to `importlib_metadata`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,9 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "sopel>=7.1",
+    # sopel also requires both of the below, but it's best to be explicit
     "requests",
+    "importlib_metadata>=3.6",
 ]
 
 [project.urls]

--- a/sopel_help/providers.py
+++ b/sopel_help/providers.py
@@ -5,6 +5,7 @@ import socket
 import urllib
 
 import requests
+
 from sopel.tools import get_logger
 
 from sopel_help import mixins


### PR DESCRIPTION
This fixes installing `sopel` (which depends on this package) from scratch on a new environment that does not ship with `pkg_resources` as part of the Python stdlib (py3.12+) and also omits `setuptools` (some distros, fresh venvs, probably others).

Also includes slight cleanup of comments, log messages, and imports, but I think not enough to be worth a separate commit or pull request.

Progresses #11, but not all the way to completion (it asks for `importlib.metadata`, which we can't use for this purpose in its stdlib flavor until Python 3.10 is the minimum version required).