### PR TITLE
meta: bump to 0.5.2 and fix pylint<3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,23 @@ jobs:
           - "3.9"
           - "3.10"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade wheel
+          python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade -r requirements.txt
+          python -m pip install "sopel<8"
           python -m pip install -e .
       - name: Lint
-        run: make lint
+        run: |
+          isort sopel_help
+          flake8
+          pylint sopel_help
+          pyroma .
       - name: Tests
-        run: make test
+        run: |
+          coverage run -m pytest -v .

--- a/.pylintrc
+++ b/.pylintrc
@@ -302,6 +302,9 @@ max-locals=15
 # Maximum number of parents for a class (see R0901).
 max-parents=7
 
+# Maximum number of positional arguments for function / methods.
+max-positional-arguments=10
+
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=20
 

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,10 @@ coverages: coverage_report coverage_html
 .PHONY: develop qa build
 
 develop:
-	pip install -U -r requirements.txt
-	pip install -e .
+	python -m pip install -U pip
+	python -m pip install -U wheel
+	python -m pip install -U  -r requirements.txt
+	python -m pip install -e .
 
 qa: lint-check test coverages lint-style
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ namespaces = false
 
 [project]
 name = "sopel-help"
-version = "0.5.1"
+version = "0.5.2"
 description = "Help plugin for Sopel"
 keywords = ["sopel", "irc", "help", "doc", "plugin"]
 maintainers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # requirements for dev
 
 flake8
-pylint
+pylint<3
 coverage
 pytest
 requests-mock


### PR DESCRIPTION
Apparently pylint dropped support for Py3.8, and added a bunch of new rules. As a result, the current CI trips over.

This is an attempt at hotfixing that by using pylint<3 (so pylint 2.x) until I decided how to approach the situation exactly.